### PR TITLE
don't return symlink inodes if we don't have a executable target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-        rust: [ 1.49.0 ]
+        rust: [ 1.50.0 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ 1.49.0 ]
+        rust: [ 1.50.0 ]
     steps:
       - name: Install rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
We set TTL of our inode lookup to 0 so that the kernel asks us for every
process. By looking up the path of an executable at this point in time
we will only return symlinks we have a valid target for.