### PR TITLE
always resolve fallback paths

### DIFF
--- a/nixos-test.nix
+++ b/nixos-test.nix
@@ -26,6 +26,8 @@ makeTest {
         # check fallback paths
         "PATH= /usr/bin/sh --version",
         "PATH= /usr/bin/env --version",
+        "PATH= test -e /usr/bin/sh",
+        "PATH= test -e /usr/bin/env",
         # no stat
         "! test -e /usr/bin/cp",
         # also picks up PATH that was set after execve


### PR DESCRIPTION
These paths will be always found even if PATH is unset for child
processes. This will make i.e. /usr/bin/env and /bin/sh always visible
and hence will be more compatible to the standard nixos behavior. This
fixes make for me that tries to do stat on `/bin/sh`.