### PR TITLE
use configured environment.usrbinenv and environment.binsh

### DIFF
--- a/modules/envfs.nix
+++ b/modules/envfs.nix
@@ -8,8 +8,8 @@ let
       options = [
         "fallback-path=${pkgs.runCommand "fallback-path" {} ''
           mkdir -p $out
-          ln -s ${pkgs.coreutils}/bin/env $out/env
-          ln -s ${config.system.build.binsh}/bin/sh $out/sh
+          ln -s ${config.environment.usrbinenv} $out/env
+          ln -s ${config.environment.binsh} $out/sh
         ''}"
       ];
     };


### PR DESCRIPTION
This adjusts the fallback paths to use the exact options that the activation scripts use to determine what binaries need to go to `/bin/sh` and `/usr/bin/env`

This shouldn't matter for most systems and is really mostly a nit, but this is just in case someone overrides those