### PR TITLE
add remount option which ignores the request

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ struct Options {
     debug: bool,
     show_help: bool,
     foreground: bool,
+    remount: bool,
     fallback_paths: Vec<PathBuf>,
     args: Vec<String>,
 }
@@ -123,6 +124,9 @@ fn parse_mount_options(mount_options: &str, opts: &mut Options) -> Result<()> {
         match mount_opt[0] {
             // ignore
             "ro" | "rw" => {}
+            "remount" => {
+                opts.remount = true;
+            }
             "debug" => {
                 opts.debug = true;
             }
@@ -147,6 +151,7 @@ fn parse_options(args: &[String]) -> Result<Options> {
         debug: false,
         show_help: false,
         foreground: false,
+        remount: false,
         fallback_paths: vec![],
         args: vec![],
     };
@@ -204,6 +209,10 @@ fn run_app(args: &[String]) -> i32 {
 
     if opts.show_help {
         show_help(app_name);
+        return 0;
+    }
+    if opts.remount {
+        eprintln!("Ignoring remount request.");
         return 0;
     }
     if opts.debug {


### PR DESCRIPTION
So sometimes during `nixos-rebuild switch` it calls `systemctl reload usr-bin.mount` since systemd marks all mount units as reloadable (which sounds questionable for FUSE mounts, but there's no fstab option to disable that afaik). When systemd reloads a mount it calls the mount program again with `remount` and expects it to communicate with the existing mount to change the options, which causes failures for envfs which does not support that

Let me know if there is a better way to handle this, but I've basically just patched envfs to log and ignore all remount requests to make those unit errors go away