### PR TITLE
nixos: mount with nofail

### DIFF
--- a/modules/envfs.nix
+++ b/modules/envfs.nix
@@ -11,12 +11,13 @@ let
           ln -s ${config.environment.usrbinenv} $out/env
           ln -s ${config.environment.binsh} $out/sh
         ''}"
+        "nofail"
       ];
     };
     "/bin" = {
       device = "/usr/bin";
       fsType = "none";
-      options = [ "bind" ];
+      options = [ "bind" "nofail" ];
     };
   };
 in {


### PR DESCRIPTION
We usually don't want to bring the whole machine into emergency mode just because we couldn't mount envfs. It's usually not on the critical path.