### PR TITLE
fix: whitelist syscalls for fish shell

### DIFF
--- a/nixos-test.nix
+++ b/nixos-test.nix
@@ -34,8 +34,6 @@ testers.runNixOSTest {
         # Check bind mount
         "PATH= /bin/sh --version",
         "PATH=/usr/bin:/bin /bin/sh --version",
-        # no stat
-        "! test -e /usr/bin/cp",
         # also picks up PATH that was set after execve
         "! /usr/bin/hello",
         "PATH=${hello}/bin /usr/bin/hello",

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -359,6 +359,23 @@ fn is_execve_syscall(num: usize) -> bool {
     num == libc::SYS_execve as usize || num == libc::SYS_execveat as usize
 }
 
+#[cfg(not(target_arch = "aarch64"))]
+fn is_access_syscall(num: usize) -> bool {
+    num == libc::SYS_access as usize
+        || num == libc::SYS_faccessat as usize
+        || num == libc::SYS_faccessat2 as usize
+}
+
+#[cfg(target_arch = "aarch64")]
+fn is_access_syscall(num: usize) -> bool {
+    num == libc::SYS_faccessat as usize || num == libc::SYS_faccessat2 as usize
+}
+
+// TODO: Currently only supports arch which has the newfstatat system call
+fn is_fstatat_syscall(num: usize) -> bool {
+    num == libc::SYS_newfstatat as usize
+}
+
 fn resolve_target<P1, P2>(
     pid: Pid,
     name: P1,
@@ -422,6 +439,8 @@ where
     // We need to allow open/openat because some programs want to open themself, i.e. bash
     let allowed_syscall = is_open_syscall(args[0])
         || is_execve_syscall(args[0])
+        || is_access_syscall(args[0])
+        || is_fstatat_syscall(args[0])
         || env.contains_key(OsStr::new("ENVFS_RESOLVE_ALWAYS"));
 
     if allowed_syscall {


### PR DESCRIPTION
To solve https://github.com/Mic92/envfs/issues/173, some system calls are whitelisted because `fish` shell executes `execve` conditionally. It first calls `access` and `fstatat`, and if it's accessible it will then run execve. Currently, this PR only works for architectures which has `newfstatat` system call. 

Cc: @fzakaria