### PR TITLE
Safely resolve symlinks with potential recursion into envfs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.history
+/result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,22 @@
 version = 4
 
 [[package]]
-name = "bitflags"
-version = "2.4.0"
+name = "anyhow"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -40,7 +46,36 @@ dependencies = [
  "log",
  "nix 0.31.2",
  "simple-error",
+ "tempfile",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fuser"
@@ -58,16 +93,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -77,9 +182,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nix"
@@ -106,6 +211,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,21 +227,98 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.94"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -141,9 +329,9 @@ checksum = "69da7c8ef9e55986dcaa55dd095bbf7d321e80cc91644f25ce26a83dbe9e7f14"
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
@@ -153,9 +341,9 @@ checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -163,10 +351,81 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.12"
+name = "tempfile"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "winapi"
@@ -191,21 +450,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "zerocopy"
-version = "0.8.24"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ fuser = { version = "0.16", default-features = false }
 [dependencies.concurrent-hashmap]
 version = "0.2.*"
 default-features = false
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -10,7 +10,7 @@ use nix::errno::Errno;
 use nix::mount::mount;
 use nix::unistd::{self, Pid};
 use simple_error::try_with;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::env;
 use std::ffi::{CStr, CString};
 use std::ffi::{OsStr, OsString};
@@ -258,23 +258,78 @@ fn symlink_attr(ino: u64) -> FileAttr {
     }
 }
 
+/// Resolve a path to a real file without triggering recursion into envfs filesystems.
+///
+/// It is possible that a path component is a symlink that points into envfs,
+/// especially if using environments prepared by (e.g.) Python venvs. To be safe
+/// we also resolve intermediate paths too, though in practice these should not
+/// be an issues since envfs only resolves the final component of a path.
+fn safe_resolve_path<P>(path: &Path, mountpoints: &[P]) -> Option<PathBuf>
+where
+    P: AsRef<Path>,
+{
+    const MAX_SYMLINK_DEPTH: usize = 40;
+
+    let mut symlink_count = 0;
+    let mut resolved = PathBuf::from("/");
+    let mut queue: VecDeque<OsString> = path
+        .components()
+        .map(|c| c.as_os_str().to_owned())
+        .collect();
+
+    while let Some(component) = queue.pop_front() {
+        if component == "/" {
+            resolved = PathBuf::from("/");
+        } else if component == "." {
+            // Skip current directory components
+            continue;
+        } else if component == ".." {
+            // Handle parent directory components
+            resolved.pop();
+        } else {
+            let candidate = resolved.join(&component);
+
+            // If at any point our candidate resolution points into an envfs mountpoint
+            // we should abort at once otherwise we will induce recursion.
+            if mountpoints.iter().any(|m| candidate.starts_with(m)) {
+                return None;
+            }
+
+            let meta = candidate.symlink_metadata().ok()?;
+
+            // Do we still need this check if we already check for mountpoints?
+            if meta.nlink() as u32 == ENVFS_MAGIC {
+                return None;
+            }
+
+            if meta.file_type().is_symlink() {
+                symlink_count += 1;
+                if symlink_count > MAX_SYMLINK_DEPTH {
+                    return None;
+                }
+                let target = fs::read_link(&candidate).ok()?;
+                // Prepend the symlink target's components for processing.
+                // `resolved` stays as the current directory (parent of the symlink),
+                // which is the correct base for relative targets. It will be
+                // truncated if the target starts with "/".
+                for c in target.components().rev() {
+                    queue.push_front(c.as_os_str().to_owned());
+                }
+            } else {
+                resolved = candidate;
+            }
+        }
+    }
+
+    Some(resolved)
+}
+
 fn _which<P1, P2>(path: &Path, exe_name: P1, mountpoints: &[P2]) -> Option<PathBuf>
 where
     P1: AsRef<Path>,
     P2: AsRef<Path>,
 {
-    if mountpoints.iter().any(|m| path.starts_with(m)) {
-        return None;
-    }
-
-    // Do we still need this check if we already check for mountpoints?
-    if let Ok(stat) = path.symlink_metadata() {
-        if stat.nlink() as u32 == ENVFS_MAGIC {
-            return None;
-        }
-    }
-
-    let full_path = path.join(&exe_name);
+    let full_path = safe_resolve_path(&path.join(&exe_name), mountpoints)?;
     let res = unistd::access(&full_path, unistd::AccessFlags::X_OK);
     if res.is_ok() {
         Some(full_path)

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,7 +7,9 @@ use libc::{endmntent, getmntent, setmntent, FILE};
 use libc::{ENODATA, ENOENT};
 use log::{debug, warn};
 use nix::errno::Errno;
+use nix::fcntl::{openat, AtFlags, OFlag};
 use nix::mount::mount;
+use nix::sys::stat::fstatat;
 use nix::unistd::{self, Pid};
 use simple_error::try_with;
 use std::collections::{HashMap, VecDeque};
@@ -21,8 +23,8 @@ use std::io::{BufRead, BufReader};
 use std::io::{Read, SeekFrom};
 use std::mem::size_of;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
-use std::os::unix::fs::MetadataExt;
-use std::path::{Path, PathBuf};
+use std::os::unix::io::OwnedFd;
+use std::path::{Component, Path, PathBuf};
 use std::ptr;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, UNIX_EPOCH};
@@ -258,12 +260,25 @@ fn symlink_attr(ino: u64) -> FileAttr {
     }
 }
 
+/// Open the root directory as an O_PATH fd.
+fn open_root() -> Option<OwnedFd> {
+    nix::fcntl::open(
+        Path::new("/"),
+        OFlag::O_PATH | OFlag::O_DIRECTORY,
+        nix::sys::stat::Mode::empty(),
+    )
+    .ok()
+}
+
 /// Resolve a path to a real file without triggering recursion into envfs filesystems.
 ///
-/// It is possible that a path component is a symlink that points into envfs,
-/// especially if using environments prepared by (e.g.) Python venvs. To be safe
-/// we also resolve intermediate paths too, though in practice these should not
-/// be an issues since envfs only resolves the final component of a path.
+/// Uses O_PATH file descriptors with openat()/fstatat()/readlinkat() so that
+/// each component is resolved one hop at a time relative to an already-open
+/// parent fd. This avoids full path traversals by the kernel, which would
+/// deadlock if any component lives on an envfs mountpoint.
+///
+/// Returns `None` when the path is unresolvable or when resolution would enter
+/// an envfs mountpoint.
 fn safe_resolve_path<P>(path: &Path, mountpoints: &[P]) -> Option<PathBuf>
 where
     P: AsRef<Path>,
@@ -272,52 +287,78 @@ where
 
     let mut symlink_count = 0;
     let mut resolved = PathBuf::from("/");
+    let mut dir_fd: OwnedFd = open_root()?;
     let mut queue: VecDeque<OsString> = path
         .components()
         .map(|c| c.as_os_str().to_owned())
         .collect();
 
     while let Some(component) = queue.pop_front() {
-        if component == "/" {
-            resolved = PathBuf::from("/");
-        } else if component == "." {
-            // Skip current directory components
-            continue;
-        } else if component == ".." {
-            // Handle parent directory components
-            resolved.pop();
-        } else {
-            let candidate = resolved.join(&component);
-
-            // If at any point our candidate resolution points into an envfs mountpoint
-            // we should abort at once otherwise we will induce recursion.
-            if mountpoints.iter().any(|m| candidate.starts_with(m)) {
-                return None;
+        let comp_path = Path::new(&component);
+        match comp_path.components().next()? {
+            Component::RootDir => {
+                resolved = PathBuf::from("/");
+                dir_fd = open_root()?;
             }
-
-            let meta = candidate.symlink_metadata().ok()?;
-
-            // Do we still need this check if we already check for mountpoints?
-            if meta.nlink() as u32 == ENVFS_MAGIC {
-                return None;
+            Component::CurDir => continue,
+            Component::ParentDir => {
+                resolved.pop();
+                dir_fd = openat(
+                    &dir_fd,
+                    Path::new(".."),
+                    OFlag::O_PATH | OFlag::O_DIRECTORY,
+                    nix::sys::stat::Mode::empty(),
+                )
+                .ok()?;
             }
+            Component::Normal(name) => {
+                let candidate = resolved.join(name);
 
-            if meta.file_type().is_symlink() {
-                symlink_count += 1;
-                if symlink_count > MAX_SYMLINK_DEPTH {
+                // Abort if resolution would enter an envfs mountpoint.
+                if mountpoints.iter().any(|m| candidate.starts_with(m)) {
                     return None;
                 }
-                let target = fs::read_link(&candidate).ok()?;
-                // Prepend the symlink target's components for processing.
-                // `resolved` stays as the current directory (parent of the symlink),
-                // which is the correct base for relative targets. It will be
-                // truncated if the target starts with "/".
-                for c in target.components().rev() {
-                    queue.push_front(c.as_os_str().to_owned());
+
+                // Stat the component via the parent fd without following
+                // symlinks. This never triggers FUSE open/read on the child.
+                let stat = fstatat(&dir_fd, Path::new(name), AtFlags::AT_SYMLINK_NOFOLLOW).ok()?;
+
+                // Defense-in-depth: catch envfs inodes even if the
+                // mountpoints list is incomplete or stale.
+                if stat.st_nlink as u32 == ENVFS_MAGIC {
+                    return None;
                 }
-            } else {
-                resolved = candidate;
+
+                if (stat.st_mode & libc::S_IFMT) == libc::S_IFLNK {
+                    symlink_count += 1;
+                    if symlink_count > MAX_SYMLINK_DEPTH {
+                        return None;
+                    }
+                    let target = nix::fcntl::readlinkat(&dir_fd, Path::new(name)).ok()?;
+                    // Prepend the symlink target's components for processing.
+                    // `resolved`/`dir_fd` stay as the parent of the symlink,
+                    // which is the correct base for relative targets. An
+                    // absolute target will begin with Component::RootDir,
+                    // resetting both.
+                    let target_path = PathBuf::from(target);
+                    for c in target_path.components().rev() {
+                        queue.push_front(c.as_os_str().to_owned());
+                    }
+                } else {
+                    // Advance into this component.  O_PATH means the kernel
+                    // performs a single directory lookup and never sends a FUSE
+                    // open/read request.
+                    dir_fd = openat(
+                        &dir_fd,
+                        Path::new(name),
+                        OFlag::O_PATH,
+                        nix::sys::stat::Mode::empty(),
+                    )
+                    .ok()?;
+                    resolved = candidate;
+                }
             }
+            Component::Prefix(_) => unreachable!("no Windows prefixes on Linux"),
         }
     }
 
@@ -705,5 +746,86 @@ impl Filesystem for EnvFs {
         }
         let data = inode.path.as_os_str().as_bytes();
         reply.data(data);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs as unix_fs;
+    use tempfile::TempDir;
+
+    /// Helper: create a file inside a directory, creating parents as needed.
+    fn touch(base: &Path, rel: &str) {
+        let p = base.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&p, "").unwrap();
+    }
+
+    #[test]
+    fn resolves_plain_path() {
+        let tmp = TempDir::new().unwrap();
+        touch(tmp.path(), "a/b/c");
+
+        let mountpoints: Vec<PathBuf> = vec![];
+        let resolved = safe_resolve_path(&tmp.path().join("a/b/c"), &mountpoints);
+        assert_eq!(resolved, Some(tmp.path().join("a/b/c")));
+    }
+
+    #[test]
+    fn rejects_path_into_mountpoint() {
+        let tmp = TempDir::new().unwrap();
+        touch(tmp.path(), "usr/bin/sh");
+
+        let mountpoints = vec![tmp.path().join("usr/bin")];
+        let resolved = safe_resolve_path(&tmp.path().join("usr/bin/sh"), &mountpoints);
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn rejects_symlink_pointing_into_mountpoint() {
+        // Reproduces the Python venv deadlock from #196: a symlink on PATH
+        // points into an envfs mountpoint.
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("usr/bin")).unwrap();
+        touch(tmp.path(), "usr/bin/python");
+        fs::create_dir_all(tmp.path().join("venv/bin")).unwrap();
+        unix_fs::symlink(
+            tmp.path().join("usr/bin/python"),
+            tmp.path().join("venv/bin/python"),
+        )
+        .unwrap();
+
+        let mountpoints = vec![tmp.path().join("usr/bin")];
+        let resolved = safe_resolve_path(&tmp.path().join("venv/bin/python"), &mountpoints);
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn rejects_symlink_loop() {
+        let tmp = TempDir::new().unwrap();
+        unix_fs::symlink(tmp.path().join("b"), tmp.path().join("a")).unwrap();
+        unix_fs::symlink(tmp.path().join("a"), tmp.path().join("b")).unwrap();
+
+        let mountpoints: Vec<PathBuf> = vec![];
+        let resolved = safe_resolve_path(&tmp.path().join("a"), &mountpoints);
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn rejects_indirect_symlink_into_mountpoint() {
+        // link1 -> link2 -> /mountpoint/exe: chained symlinks that
+        // eventually land in an envfs mountpoint.
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("mnt")).unwrap();
+        touch(tmp.path(), "mnt/exe");
+        unix_fs::symlink(tmp.path().join("mnt/exe"), tmp.path().join("link2")).unwrap();
+        unix_fs::symlink(tmp.path().join("link2"), tmp.path().join("link1")).unwrap();
+
+        let mountpoints = vec![tmp.path().join("mnt")];
+        let resolved = safe_resolve_path(&tmp.path().join("link1"), &mountpoints);
+        assert_eq!(resolved, None);
     }
 }


### PR DESCRIPTION
This patch adds support for safely resolving executables that end up being symlinks on the path in various contexts, such as oddly configured python environments (as discussed in #196). This patch makes sure that symlinks are fully resolved to paths that are completely outside of envfs mountpoints, since otherwise these leads to deadlocks on the host system that require rebooting to recover from... and interrupts workflows. Personally, I keep stumbling across this due to my work in the Python venvs and get caught by surprise each time. Even if you don't come across this case often, I don't think it is a good idea to have the system effectively crash when symlinks into envfs filesystems are found on the path.

I've been running this branch on my system for a while now and it fixes all the hangups I was seeing.

closes: #196 