### PR TITLE
Fix `fileSystems."/bin".fsType accessed but undefined` on nixos-unstable

### DIFF
--- a/modules/envfs.nix
+++ b/modules/envfs.nix
@@ -20,7 +20,7 @@ let
     # Systemd is smart enough to not mount /bin if it's already mounted.
     "/bin" = {
       device = "/usr/bin";
-      fsType = "auto";
+      fsType = lib.mkDefault "auto";
       options = [ "bind" "nofail" ];
     };
   };

--- a/modules/envfs.nix
+++ b/modules/envfs.nix
@@ -20,6 +20,7 @@ let
     # Systemd is smart enough to not mount /bin if it's already mounted.
     "/bin" = {
       device = "/usr/bin";
+      fsType = "auto";
       options = [ "bind" "nofail" ];
     };
   };


### PR DESCRIPTION
as https://github.com/NixOS/nixpkgs/pull/444829 is merged, the `/bin` mount must be explicitly defined with an `fsType` value.

this pr assumes that the previous default behaviour of `fsType` is preferred. if not, please let me know what the type should be set to.